### PR TITLE
SkirtSupporterPBによる変更を戻せない不具合の修正

### DIFF
--- a/SkirtSupporterPB/Script/Editor/SkirtSupporterPBEditor.cs
+++ b/SkirtSupporterPB/Script/Editor/SkirtSupporterPBEditor.cs
@@ -104,7 +104,7 @@ public class SkirtSupporterPBEditor : Editor
         targets.Add(skirtSupporter.hips.Find("_SubLegL"));
         targets.Add(skirtSupporter.rightUpperLeg.Find("PBC_R"));
         targets.Add(skirtSupporter.leftUpperLeg.Find("PBC_L"));
-        targets.Add(skirtSupporter.hips.parent.Find("_HangFrontTarget"));
+        targets.Add(skirtSupporter.hips.Find("_HangFrontTarget"));
         targets.Add(skirtSupporter.hips.parent.Find("_HangAimParent"));
 
         // 旧SkirtSupporterの要素やDynamicBoneを削除

--- a/SkirtSupporterPB/Script/Editor/SkirtSupporterPBEditor.cs
+++ b/SkirtSupporterPB/Script/Editor/SkirtSupporterPBEditor.cs
@@ -328,23 +328,30 @@ public class SkirtSupporterPBEditor : Editor
 
     private void ClearSkirtHangObject()
     {
+        Transform skirtparent = null;
+
         foreach (SkirtSupporterPB.BoneSet skirt in skirtSupporter.skirtBones)
         {
             if (skirt.boneObject.transform.parent != skirtSupporter.skirtsParent)
             {
                 var parent = skirt.boneObject.transform.parent;
+                if (parent != null)
+                {
+                    skirtparent = parent;
+                }
                 skirt.boneObject.transform.SetParent(skirtSupporter.skirtsParent.transform, true);
-                if (parent != null && parent.name == "SkirtRoot")
-                {
-                    DestroyImmediate(parent.gameObject);
-                }
-                else if (parent != null && parent.name == "SkirtBranch")
-                {
-                    if (parent.parent != null && parent.parent.name == "SkirtRoot")
-                    {
-                        DestroyImmediate(parent.parent.gameObject);
-                    }
-                }
+            }
+        }
+
+        if (skirtparent != null && skirtparent.name == "SkirtRoot")
+        {
+            DestroyImmediate(skirtparent.gameObject);
+        }
+        else if (skirtparent != null && skirtparent.name == "SkirtBranch")
+        {
+            if (skirtparent.parent != null && skirtparent.parent.name == "SkirtRoot")
+            {
+                DestroyImmediate(skirtparent.parent.gameObject);
             }
         }
     }


### PR DESCRIPTION
## 内容

 1. ClearSkirtHangObject()が2番目以降のスカートボーンを親ごと削除してしまう不具合の修正
 1. _HangFrontTargetが実行ごとに複製される不具合の修正

## 確認手順

#### No.1について

  1. skirtHangをTrueとしPhysBone＆Collider生成を実行
  1. skirtHangをFalseとしPhysBone＆Collider生成を実行

#### 修正後に期待される動作
 2番目以降のスカートボーンが正しく復元される
___
#### No.2について

  1. skirtHangをTrueとしPhysBone＆Collider生成を実行
  1. 再度PhysBone＆Collider生成を実行

#### 修正後に期待される動作
 _HangFrontTargetは一つ以上出現しない
